### PR TITLE
Add OS-specific files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ bun-debug.log*
 # Private journal artifacts (should not be committed)
 /.private-journal/
 *.embedding
+
+# OS files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Added OS-specific files to .gitignore

This PR adds common operating system generated files to the .gitignore:
- `.DS_Store` (macOS directory metadata files)
- `Thumbs.db` (Windows thumbnail cache files)

These files are automatically created by operating systems and should not be tracked in version control.