### PR TITLE
Update changesets/action to v1 and reorder package.json exports

### DIFF
--- a/.github/workflows/ci-bun.yml
+++ b/.github/workflows/ci-bun.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@e0145ed # v1
+        uses: changesets/action@v1
         with:
           publish: bun run release
         env:

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,9 +8,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     }
   },
   "files": [


### PR DESCRIPTION
This PR updates the GitHub Actions workflow and package.json configuration:

1. Updates the changesets/action reference in the CI workflow from a commit hash (`e0145ed`) to the versioned tag (`v1`) for better maintainability.

2. Reorders the exports field in the core package.json to place the "types" entry before "import" and "require", improving the logical organization of the package exports configuration.