### PR TITLE
chore: replace node.js with bun runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,9 @@ jobs:
 
       - name: Typecheck
         run: bun run typecheck
-        continue-on-error: true
 
       - name: Test
-        run: bun run test
-        continue-on-error: true
+        run: bun run test --coverage
 
       - name: Build
         run: bun run build
@@ -67,11 +65,9 @@ jobs:
       
       - name: Typecheck
         run: bun run typecheck
-        continue-on-error: true
       
       - name: Test
-        run: bun run test
-        continue-on-error: true
+        run: bun run test --coverage
       
       - name: Build
         run: bun run build

--- a/README.md
+++ b/README.md
@@ -226,8 +226,10 @@ bun install
 # Build all packages
 bun run build
 
-# Run tests
-bun test
+# Lint, typecheck, and run tests with coverage
+bun run lint
+bun run typecheck
+bun run test --coverage
 ```
 
 ### Packages


### PR DESCRIPTION
# Enforce Strict CI Checks and Add Test Coverage

This PR improves our CI workflow by making typechecking and testing mandatory steps that must pass for the workflow to succeed. Key changes include:

- Removed `continue-on-error: true` from typecheck steps in CI workflows
- Removed `continue-on-error: true` from test steps in CI workflows
- Added `--coverage` flag to test commands to generate test coverage reports
- Updated README documentation to reflect the improved testing approach with coverage

These changes ensure that our codebase maintains high quality standards by failing CI when typechecking or tests fail, while also providing better visibility into test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Test coverage is now collected and reported during CI runs.
- Tests
  - CI no longer ignores type check or test failures, ensuring accurate build status.
- Documentation
  - Updated development workflow to run linting, type checks, and tests with coverage; refreshed command guidance.
- Chores
  - Streamlined CI configuration for more reliable and consistent feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->