### PR TITLE
docs: clarify active documentation sources

### DIFF
--- a/.agents/docs/language.md
+++ b/.agents/docs/language.md
@@ -164,7 +164,7 @@ When referring to compilation versions:
 ## Terminology Best Practices
 
 - Be consistent with terminology across all documentation and code
-- Align new terminology with the music production theme when appropriate
+- Avoid thematic metaphors—describe concepts with plain, tool-agnostic language
 - When new terms are introduced, add them to this language spec
 - Prefer clarity over cleverness in technical documentation
 - Use examples liberally to illustrate abstract concepts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Rulesets is a CommonMark-compliant rules compiler that lets you author a single 
 
 ## Project Structure for AI Agent Navigation
 
-- `/docs`: Project documentation that AI agents should consult
+- `/docs`: Legacy documentation (reference only; migrate material into `.agents/docs/`)
   - `.agents/docs/language.md`: Terminology and language spec for consistent communication
   - `.agents/docs/overview.md`: Project overview and guidance
   - `.agents/docs/architecture.md`: Technical architecture details

--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -89,6 +89,10 @@ Pay close attention to the @MIGRATION.md document.
 - Updated provider instantiation/export map, logging metadata, and re-exports; refreshed README examples accordingly.
 - Verified provider test suite via `bun run --filter @rulesets/core test`.
 
+#### 2025-09-21 at 11:35
+
+- Clarified documentation sources in `AGENTS.md` and removed the lingering music-metaphor note from `.agents/docs/language.md` per doc-reorg review feedback.
+
 ### 2025-09-19
 
 #### 2025-09-19 at 15:16


### PR DESCRIPTION
### TL;DR

Updated documentation to remove thematic metaphors and clarify documentation sources.

### What changed?

- Modified `.agents/docs/language.md` to recommend using plain, tool-agnostic language instead of music production themed metaphors
- Updated `AGENTS.md` to mark `/docs` as legacy documentation that should only be referenced, with a note to migrate content to `.agents/docs/`
- Added an entry in `SCRATCHPAD.md` documenting these changes

### How to test?

- Review the updated language guidelines in `.agents/docs/language.md`
- Verify the documentation source hierarchy described in `AGENTS.md`
- Confirm the changes align with the doc-reorg review feedback mentioned in the scratchpad

### Why make this change?

This change improves documentation clarity by removing potentially confusing thematic metaphors and establishes a clear documentation hierarchy. It addresses specific feedback from a documentation reorganization review to ensure consistent and straightforward technical communication throughout the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised terminology guidance to avoid thematic metaphors; promote plain, tool-agnostic language.
  * Reframed the main docs directory as legacy and added clear migration guidance to the new agent-focused docs area.
  * Expanded project navigation notes to include curated research notes for rulesets.
  * Clarified documentation sources and removed outdated music-metaphor references.
  * No changes to public APIs or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->