### PR TITLE
fix: finalize partials review adjustments

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -100,6 +100,11 @@ Pay close attention to the @MIGRATION.md document.
   - Extracted regex patterns to module constants for better performance
 - All tests passing after improvements (`bun run --filter @rulesets/core test`)
 
+#### 2025-09-21 at 09:20
+
+- Applied follow-up review tweaks to partials support: reordered common extensions list for faster checks, enriched partial load logging with attempted extension, and added validation for inline Handlebars partial identifiers in destination config.
+- Verified `@rulesets/core` suite remains green with `bun run --filter @rulesets/core test`.
+
 #### 2025-09-21 at 10:05
 
 - Hardened Handlebars compiler defaults (strict mode enabled, escaping enforced) with optional overrides and centralized body extraction via `utils/frontmatter.ts`.
@@ -131,6 +136,10 @@ Pay close attention to the @MIGRATION.md document.
 
 - Fixed CLI smoke tests by standardising on the Bun runtime: updated the CLI shebang, removed the redundant tsup banner, and adjusted the test harness to invoke the compiled binary via `process.execPath`; `bun run --filter @rulesets/cli test` now passes.
 - End-to-end validation: `bun run lint`, `bun run typecheck`, `bun run test --coverage`, and `bun run build` all succeed on the top of stack; verified `./packages/cli/dist/index.js --help` and `--version` execute successfully.
+
+#### 2025-09-21 at 12:40
+
+- Addressed remaining review feedback: partial loader now processes sources sequentially, provider helpers/partials validate input deterministically, and new compiler/provider tests cover security + override behaviour. Entire stack (#15→#21) currently green awaiting refreshed CodeRabbit reviews.
 
 ### 2025-09-19
 

--- a/packages/core/src/compiler/index.ts
+++ b/packages/core/src/compiler/index.ts
@@ -6,8 +6,6 @@ import { extractBodyFromContent } from '../utils/frontmatter';
 
 export { HandlebarsRulesetCompiler } from './handlebars-compiler';
 
-export { HandlebarsRulesetCompiler } from './handlebars-compiler';
-
 const handlebarsCompiler = new HandlebarsRulesetCompiler();
 
 function prefersHandlebars(

--- a/packages/core/src/destinations/agents-md-provider.ts
+++ b/packages/core/src/destinations/agents-md-provider.ts
@@ -31,7 +31,7 @@ export class AgentsMdProvider implements DestinationProvider {
     };
   }
 
-  async prepareCompilation({
+  prepareCompilation({
     parsed,
     projectConfig: _projectConfig,
     logger,

--- a/packages/core/src/destinations/claude-code-provider.ts
+++ b/packages/core/src/destinations/claude-code-provider.ts
@@ -31,7 +31,7 @@ export class ClaudeCodeProvider implements DestinationProvider {
     };
   }
 
-  async prepareCompilation({
+  prepareCompilation({
     parsed,
     projectConfig: _projectConfig,
     logger,

--- a/packages/core/src/destinations/copilot-provider.ts
+++ b/packages/core/src/destinations/copilot-provider.ts
@@ -31,7 +31,7 @@ export class CopilotProvider implements DestinationProvider {
     };
   }
 
-  async prepareCompilation({
+  prepareCompilation({
     parsed,
     projectConfig: _projectConfig,
     logger,

--- a/packages/core/src/destinations/utils.ts
+++ b/packages/core/src/destinations/utils.ts
@@ -7,68 +7,21 @@ import type {
 
 export type UnknownRecord = Record<string, unknown>;
 
-export function isPlainObject(value: unknown): value is UnknownRecord {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
-}
+type HandlebarsConfigShape = {
+  force?: unknown;
+  enabled?: unknown;
+  partials?: unknown;
+  projectConfigOverrides?: unknown;
+};
 
 const HANDLEBARS_PARTIAL_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_-]*$/;
 
-function isValidPartialName(name: string): boolean {
+function isValidHandlebarsPartialName(name: string): boolean {
   return HANDLEBARS_PARTIAL_NAME_PATTERN.test(name);
 }
 
-function addAdditionalPartials(
-  target: Map<string, string>,
-  additional: Record<string, string> | undefined
-): void {
-  if (!additional) {
-    return;
-  }
-
-  for (const [name, template] of Object.entries(additional)) {
-    if (typeof template === 'string' && template.trim().length > 0) {
-      target.set(name, template);
-    }
-  }
-}
-
-function addConfiguredPartials(
-  target: Map<string, string>,
-  partialsConfig: unknown,
-  destinationId: string,
-  logger: Logger
-): void {
-  if (partialsConfig === undefined) {
-    return;
-  }
-
-  if (!isPlainObject(partialsConfig)) {
-    logger.warn('Ignoring non-object Handlebars partials configuration', {
-      destination: destinationId,
-    });
-    return;
-  }
-
-  for (const [name, template] of Object.entries(
-    partialsConfig as UnknownRecord
-  )) {
-    if (!isValidPartialName(name)) {
-      logger.warn('Invalid Handlebars partial name, skipping entry', {
-        destination: destinationId,
-        partial: name,
-      });
-      continue;
-    }
-
-    if (typeof template === 'string' && template.trim().length > 0) {
-      target.set(name, template);
-    } else if (template !== undefined) {
-      logger.warn('Ignoring non-string Handlebars partial', {
-        destination: destinationId,
-        partial: name,
-      });
-    }
-  }
+export function isPlainObject(value: unknown): value is UnknownRecord {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
 export function readDestinationConfig(
@@ -77,18 +30,23 @@ export function readDestinationConfig(
 ): UnknownRecord | undefined {
   const frontmatter = parsed.source.frontmatter;
   if (!isPlainObject(frontmatter)) {
-    return undefined;
+    return;
   }
 
   const destinations = frontmatter.destinations;
   if (!isPlainObject(destinations)) {
-    return undefined;
+    return;
   }
 
-  const destinationConfig = destinations[destinationId];
-  return isPlainObject(destinationConfig) ? destinationConfig : undefined;
+  const config = destinations[destinationId];
+  if (!isPlainObject(config)) {
+    return;
+  }
+
+  return config;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Handlebars option parsing requires multiple validation branches.
 export function buildHandlebarsOptions(opts: {
   destinationId: string;
   destinationConfig?: UnknownRecord;
@@ -99,22 +57,15 @@ export function buildHandlebarsOptions(opts: {
   const {
     destinationId,
     destinationConfig,
-    logger,
     helpers,
     additionalPartials,
+    logger,
   } = opts;
 
-  if (!isPlainObject(destinationConfig)) {
-    return undefined;
-  }
+  const rawHandlebarsConfig = destinationConfig?.handlebars;
 
-  const handlebarsConfigRaw = destinationConfig.handlebars;
-  if (handlebarsConfigRaw === undefined) {
-    return undefined;
-  }
-
-  if (handlebarsConfigRaw === true) {
-    const gatheredPartials =
+  if (rawHandlebarsConfig === true) {
+    const partialsFromAdditional =
       additionalPartials && Object.keys(additionalPartials).length > 0
         ? additionalPartials
         : undefined;
@@ -123,62 +74,84 @@ export function buildHandlebarsOptions(opts: {
       handlebars: {
         force: true,
         helpers,
-        partials: gatheredPartials,
+        partials: partialsFromAdditional,
       },
     };
   }
 
-  if (!isPlainObject(handlebarsConfigRaw)) {
+  if (
+    rawHandlebarsConfig !== undefined &&
+    !isPlainObject(rawHandlebarsConfig)
+  ) {
     logger.warn('Ignoring invalid Handlebars configuration', {
       destination: destinationId,
-      value: handlebarsConfigRaw,
+      value: rawHandlebarsConfig,
     });
-    return undefined;
+    return;
   }
 
-  const handlebarsConfig = handlebarsConfigRaw as UnknownRecord;
+  const handlebarsConfig = rawHandlebarsConfig as
+    | HandlebarsConfigShape
+    | undefined;
 
   const partials = new Map<string, string>();
-  addAdditionalPartials(partials, additionalPartials);
-  addConfiguredPartials(
-    partials,
-    handlebarsConfig.partials,
-    destinationId,
-    logger
-  );
+  if (additionalPartials) {
+    for (const [name, template] of Object.entries(additionalPartials)) {
+      if (typeof template === 'string' && template.trim().length > 0) {
+        partials.set(name, template);
+      }
+    }
+  }
+
+  if (isPlainObject(handlebarsConfig?.partials)) {
+    const partialRecords = handlebarsConfig.partials as UnknownRecord;
+    for (const [name, template] of Object.entries(partialRecords)) {
+      if (!isValidHandlebarsPartialName(name)) {
+        logger.warn('Invalid Handlebars partial name, skipping entry', {
+          destination: destinationId,
+          partial: name,
+        });
+        continue;
+      }
+      if (typeof template === 'string' && template.trim().length > 0) {
+        partials.set(name, template);
+      } else if (template !== undefined) {
+        logger.warn('Ignoring non-string Handlebars partial', {
+          destination: destinationId,
+          partial: name,
+        });
+      }
+    }
+  }
 
   const force =
-    handlebarsConfig.force === true || handlebarsConfig.enabled === true;
-  const gatheredHelpers =
-    helpers && Object.keys(helpers).length > 0 ? helpers : undefined;
-  const gatheredPartials =
-    partials.size > 0 ? Object.fromEntries(partials.entries()) : undefined;
+    handlebarsConfig?.force === true || handlebarsConfig?.enabled === true;
   const projectConfigOverrides = isPlainObject(
-    handlebarsConfig.projectConfigOverrides
+    handlebarsConfig?.projectConfigOverrides
   )
     ? (handlebarsConfig.projectConfigOverrides as UnknownRecord)
     : undefined;
 
-  if (
-    !(
-      force ||
-      gatheredHelpers ||
-      gatheredPartials ||
-      projectConfigOverrides
-    )
-  ) {
-    return undefined;
+  const helperEntries =
+    helpers && Object.keys(helpers).length > 0 ? helpers : undefined;
+  const partialsObject =
+    partials.size > 0 ? Object.fromEntries(partials) : undefined;
+
+  const hasHandlebarsOptions = force || helperEntries || partialsObject;
+  const hasOverrides = Boolean(projectConfigOverrides);
+
+  if (!(hasHandlebarsOptions || hasOverrides)) {
+    return;
   }
 
   return {
-    handlebars:
-      force || gatheredHelpers || gatheredPartials
-        ? {
-            force: force || undefined,
-            helpers: gatheredHelpers,
-            partials: gatheredPartials,
-          }
-        : undefined,
+    handlebars: hasHandlebarsOptions
+      ? {
+          force: force || undefined,
+          helpers: helperEntries,
+          partials: partialsObject,
+        }
+      : undefined,
     projectConfigOverrides,
   };
 }

--- a/packages/core/src/destinations/windsurf-provider.ts
+++ b/packages/core/src/destinations/windsurf-provider.ts
@@ -41,7 +41,7 @@ export class WindsurfProvider implements DestinationProvider {
     };
   }
 
-  async prepareCompilation({
+  prepareCompilation({
     parsed,
     projectConfig: _projectConfig,
     logger,


### PR DESCRIPTION
### TL;DR

Fixed duplicate export, removed unnecessary async declarations, and improved Handlebars configuration validation.

### What changed?

- Removed duplicate `HandlebarsRulesetCompiler` export in `compiler/index.ts`
- Changed `prepareCompilation` methods from async to sync in destination providers
- Refactored `buildHandlebarsOptions` for better validation and deterministic behavior:
  - Added type definition for Handlebars config shape
  - Improved validation for partial names with a dedicated function
  - Simplified partial loading logic
  - Enhanced error handling for invalid configurations
- Added validation for Handlebars partial identifiers in destination config

### How to test?

- Run the test suite to verify all changes work correctly:
  ```
  bun run --filter @rulesets/core test
  ```
- Verify that destination providers correctly handle Handlebars configurations with both valid and invalid partial names

### Why make this change?

These changes address review feedback to improve code quality and security. The refactoring makes the Handlebars configuration processing more deterministic and robust by validating inputs more thoroughly. Removing the async declarations from synchronous methods improves code clarity, and fixing the duplicate export eliminates a potential source of confusion.