### PR TITLE
docs: finish terminology sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Rulesets is a CommonMark-compliant rules compiler that lets you author a single 
 
 ## Project Structure for AI Agent Navigation
 
-- `/docs`: Legacy documentation (reference only; migrate material into `.agents/docs/`)
+- `/docs`: Legacy documentation (reference only; migrate relevant content into `.agents/docs/`)
   - `.agents/docs/language.md`: Terminology and language spec for consistent communication
   - `.agents/docs/overview.md`: Project overview and guidance
   - `.agents/docs/architecture.md`: Technical architecture details

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,9 @@
+## [Unreleased]
+
 ### Added
-- Standardised on the `.rule.md` file extension for source rules files (with `.ruleset.md` retained for compatibility) to improve discoverability, search capabilities, and IDE support.
+- Standardised on the `.rule.md` file extension for source rules files (keeping `.ruleset.md` for compatibility) to improve discoverability, search capabilities, and IDE support.
 
 ### Changed
-- Updated terminology throughout the documentation:
-  - "Mix files" → "Source rules"
-  - "Target" → "Destination"
-  - "Output" → "Compiled rules"
-  - "Stem" → "Section"
-  - "Option" → "Property"
-  - "Snippet" → "Mixin"
-  - `property(value)` → `property-*` and `name-("value")`
-- Updated directory structure:
-  - `.mixdown/mixes/` → `.ruleset/rules/`
-  - `.mixdown/mixes/_snippets/` → `.ruleset/rules/_mixins/`
-  - `.mixdown/output/` → `.ruleset/dist/`
+- Completed the documentation terminology sweep: Mixdown/music metaphors are now expressed as Rulesets vocabulary (source rules, destinations, sections, mixins).
+- Documented the authoritative docs location in `.agents/docs/` and clarified the provider-first terminology.
+- Updated directory references to the `.ruleset/` layout (`rules/`, `_mixins/`, `dist/`) across guidance and onboarding materials.

--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -94,6 +94,10 @@ Pay close attention to the @MIGRATION.md document.
 - Hardened CLI compile workflow: safer filename normalization (fallback to `index.md`) and richer error aggregation with per-file context.
 - Logged follow-up to re-run CLI tests (previously failing due to missing dist binaries) prior to Bun runtime alignment work.
 
+#### 2025-09-21 at 11:10
+
+- Finished documentation sweep for terminology: updated `AGENTS.md`, `docs/architecture/DECISIONS.md`, provider template, and changelog to remove Mixdown references and highlight `.agents/docs/` as the authoritative source.
+
 #### 2025-09-21 at 11:25
 
 - Updated CI workflows to run the full Bun toolchain (lint, typecheck, coverage) without allowing silent failures; documented Bun-first local development steps in the README.


### PR DESCRIPTION
### TL;DR

Completed terminology standardization across documentation, replacing music metaphors with Rulesets vocabulary.

### What changed?

- Updated `AGENTS.md` to clarify that relevant content should be migrated to `.agents/docs/`
- Refined the CHANGELOG.md to use consistent Rulesets terminology
- Documented the completion of terminology standardization in SCRATCHPAD.md
- Standardized on `.rule.md` file extension for source rules files (keeping `.ruleset.md` for backward compatibility)
- Clarified that `.agents/docs/` is the authoritative documentation location

### How to test?

- Review the updated documentation files to ensure consistent terminology
- Verify that all references to the old music metaphors (mix files, targets, stems, etc.) have been replaced with Rulesets vocabulary
- Check that directory references now correctly point to the `.ruleset/` layout

### Why make this change?

This change completes the terminology standardization effort, moving away from music metaphors to more descriptive Rulesets vocabulary. This improves clarity and consistency across the project documentation, making it easier for developers to understand the system's components and architecture. The standardized `.rule.md` file extension also enhances discoverability and IDE support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified .rule.md extension usage and confirmed .ruleset.md remains supported.
  - Consolidated terminology to “Rulesets” (source rules, destinations, sections, mixins) and updated references to the authoritative docs location.
  - Updated examples and paths to the new .ruleset layout, including rules, mixins, and dist directories.
  - Adjusted guidance and onboarding materials to reflect the new structure.
  - Logged completion of terminology updates and designated the authoritative documentation source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->